### PR TITLE
Add VSCode linting setup tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,40 @@
 
 Adds syntax highlighting to PostCSS files in Visual Studio Code.
 
+## Using PostCSS in Visual Studio Code
+
+For the best in-editor experience, use this extension in combination with [stylelint](https://marketplace.visualstudio.com/items?itemName=shinnn.stylelint) which will provide general (Post)CSS linting/syntax checks.
+
+Add a `.stylelintrc` file to your project to configure rules. For a good set of maintained rules, install this npm package to your project:
+
+    npm i -D stylelint-config-recommended
+
+Then you can extend that set of rules and just override the ones you want to change:
+
+```
+{
+  "extends": "stylelint-config-recommended",
+  "rules": {
+    ...
+  }
+}
+```
+
+If you are using any non-standard postcss modules, you can use the file extensions `.pcss` or `.postcss` to prevent VSCode's built-in CSS parser from showing unwanted errors.
+
+If you want syntax checks for `postcss-nesting` (i.e., require the `&` character) you can add this rule:
+
+```
+{
+  "extends": "stylelint-config-recommended",
+  "rules": {
+    "selector-nested-pattern": "^&"
+  }
+}
+```
+
+## Credits
+
 This is a clone of [PostCSS syntax](https://marketplace.visualstudio.com/items?itemName=ricard.PostCSS) with minor changes.
 
 The original extension does not have a github repository, so open source collaboration is impossible. This is the main reason I created this clone.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "language-postcss",
     "displayName": "language-postcss",
     "description": "PostCSS language support",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "publisher": "cpylua",
     "engines": {
         "vscode": "^1.14.0"


### PR DESCRIPTION
Previously I was using the poscss-sugarss-language extension which did a certain amount of syntax checking. Because it's no longer supported, I switched to this extension, however it only provides syntax highlighting. After some experimentation I discovered that it was better to use the `stylelint` extension for syntax/linting and use this extension for file extension recognition and syntax coloring.

I've added these tips to the readme because there may be other users out there (maybe others switching from postcss-sugarss-language) who might find this helpful.

I hope my understanding is correct. If you have any suggestions I can make changes.