### PR TITLE
docs: add instructions for PostCSS syntax in .css

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ If you want syntax checks for `postcss-nesting` (i.e., require the `&` character
 }
 ```
 
+## Use PostCSS syntax highlighting in `*.css` files
+
+To enable PostCSS syntax highlighting in `*.css` files, add the following to your VS Code settings:
+
+```
+  "files.associations": {
+    "*.css": "postcss"
+  }
+```
+
 ## TODO
 
 - [ ] Add completion for selectors, variables, properties etc.


### PR DESCRIPTION
The VS Code settings need to be tweaked for this plugin to work in `.css` files. This change adds the required settings for enabling it to the README.