### PR TITLE
CSS only supports block comments

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,5 @@
 {
     "comments": {
-        // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
         "blockComment": [ "/*", "*/" ]
     },


### PR DESCRIPTION
As far as I know, CSS only supports block comments (unless perhaps you use some postcss plugin). This switches to using /**/ for all comments. I could alternatively turn this into a configurable option (with default being /**/ since css!).

In the meantime, you can edit ~/.vscode/extensions/cpylua.language-postcss-1.0.5/language-configuration.json to get this working for you locally until this PR is merged.

Fixes #7 