### PR TITLE
remove inline comment symbol

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,5 @@
 {
     "comments": {
-        // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
         "blockComment": [ "/*", "*/" ]
     },


### PR DESCRIPTION
CSS does not support inline comment starts with `//`